### PR TITLE
Remove open-preview from .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,9 +1,11 @@
 tasks:
   - init: npm install
 
-ports:
-  - port: 4000
-    onOpen: open-preview
+# The preview opens up by the vite plugin
+# as it gets installed automatically
+# ports:
+# - port: 4000
+#   onOpen: open-preview
 
 vscode:
   extensions:


### PR DESCRIPTION
As the vite vscode plugin automatically gets installed inside a new gitpod, there is no need to open another preview. That gets handled by that plugin.